### PR TITLE
Added support for seed in generating keypair merge from bigchaindb (#487)

### DIFF
--- a/bigchaindb_driver/crypto.py
+++ b/bigchaindb_driver/crypto.py
@@ -10,9 +10,12 @@ from cryptoconditions import crypto
 CryptoKeypair = namedtuple('CryptoKeypair', ('private_key', 'public_key'))
 
 
-def generate_keypair():
+def generate_keypair(seed=None):
     """Generates a cryptographic key pair.
 
+    Args:
+        seed (bytes): 32-byte seed for deterministic generation.
+                      Defaults to `None`.
     Returns:
         :class:`~bigchaindb_driver.crypto.CryptoKeypair`: A
         :obj:`collections.namedtuple` with named fields
@@ -21,4 +24,4 @@ def generate_keypair():
 
     """
     return CryptoKeypair(
-        *(k.decode() for k in crypto.ed25519_generate_key_pair()))
+        *(k.decode() for k in crypto.ed25519_generate_key_pair(seed)))

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('CHANGELOG.rst') as changelog_file:
 
 install_requires = [
     'requests>=2.11.0',
-    'cryptoconditions==0.7.2',
+    'cryptoconditions==0.8.0',
     'pysha3~=1.0.2',
     'python-rapidjson==0.6.0',
     'python-rapidjson-schema==0.1.1',


### PR DESCRIPTION
* Added support for seed in generating keypair

* Update cryptoconditions==0.8.0 in setup.py

* Fixed a flake8 error (blank line contains whitespace)

* Fixed argument description

* Fixed a Flake8 error (line too long)

## Description
A few sentences describing the overall goals of the pull request's commits.

## Issues This PR Fixes
Fixes #NNNN
Fixes #NNNN

## Related PRs
List related PRs against other branches e.g. for backporting features/bugfixes
to previous release branches:

Repo/Branch | PR
------ | ------
some_other_PR | [link]()


## Todos
- [ ] Tested and working on development environment
- [ ] Unit tests (if appropriate)
- [ ] Added/Updated all related documentation. Add [link]() if different from this PR
- [ ] DevOps Support needed e.g. create Runscope API test if new endpoint added or
      update deployment docs. Create a ticket and add [link]()

## Deployment Notes
Notes about how to deploy this work. For example, running a migration against the production DB.

## How to QA
Outline the steps to test or reproduce the PR here.

## Impacted Areas in Application
List general components of the application that this PR will affect:
- Scale
- Performance
- Security etc.